### PR TITLE
Add the previous VS Code docs home page back

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -1,0 +1,104 @@
+<!-- Google Tag Manager -->
+   <script>
+    (function(w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+      j.setAttributeNode(d.createAttribute('data-ot-ignore'));
+      j.async = true;
+      j.src =
+        'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-PSTXMT');
+  </script>
+<!-- End Google Tag Manager -->
+
+<div class="md-content__inner md-typeset cHomeContainer">
+    <div class="row">
+        <div class="col-sm-12">
+    </br>
+        <h1>Ballerina Visual Studio Code Extension Documentation</h1>
+        </div>
+        <div class="col-sm-12" >
+        <p>The Ballerina Visual Studio Code extension is offered by WSO2 for the <a href="https://ballerina.io/">Ballerina programming language</a>. It provides a set of rich language features along with an enhanced user experience. Also, it offers easy development, execution, debugging, and testing for the Ballerina programming language.</p> 
+        <p>The Ballerina language possesses a bidirectional mapping between its syntaxes and the visual representation. You can visualize the graphical representation of your Ballerina source further via the extension.</p>
+        </div>
+    
+</div>
+
+<a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" class="cGetStartedButton">Get Started</a>
+
+
+<div class="cDocsContainer">
+    <div class="cDocsRow">  
+        <div class="cDocsGrid">
+            <a class="cIconContainer" href="edit-the-code/intellisense/">
+                <div class="cIconWrap">
+                    <img src="assets/img/home/coding.svg"/>
+                </div>
+                <div class="cDocsContainerHeader">
+                    <label>Edit the code</label>
+                </div>
+                <div class="cDocsContainerText">
+                    Use IntelliSense, code navigation, and diagnostics features in the code editor.
+                </div>
+                <div class="cDocsContainerLink">
+                    <div class="buttonText" >Learn More</div>
+                </div>
+            </a>
+        </div> 
+        <div class="cDocsGrid">
+            <a class="cIconContainer" href="visual-programming/sequence-diagram-view/">
+                <div class="cIconWrap">
+                    <img src="assets/img/home/visual.svg"/>
+                </div>
+                <div class="cDocsContainerHeader">
+                    <label>Visual programming</label>
+                </div>
+                <div class="cDocsContainerText">
+                    Learn how to write your Ballerina programs visually using a graphical editor.
+                </div>
+                <div class="cDocsContainerLink">
+                    <div class="buttonText" >Learn More</div>
+                </div>
+            </a>
+        </div>   
+        <div class="cDocsGrid">
+            <a class="cIconContainer" href="debug-the-code/debugging-overview/">
+                <div class="cIconWrap">
+                    <img src="assets/img/home/notebook.svg"/>
+                </div>
+                <div class="cDocsContainerHeader">
+                    <label>Debug the code</label>
+                </div>
+                <div class="cDocsContainerText">
+                    Learn how to debug your Ballerina programs on the VS Code editor.
+                </div>
+                <div class="cDocsContainerLink">
+                    <div class="buttonText" >Learn More</div>
+                </div>
+            </a>
+        </div>
+        <div class="cDocsGrid">
+            <a class="cIconContainer" href="configure-the-extension/">
+                <div class="cIconWrap">
+                    <img src="assets/img/home/buildandrun.svg"/>
+                </div>
+                <div class="cDocsContainerHeader">
+                    <label>Configure the extension</label>
+                </div>
+                <div class="cDocsContainerText">
+                    Try out the basic and advanced configurations of the extension.
+                </div>
+                <div class="cDocsContainerLink">
+                    <div class="buttonText" >Learn More</div>
+                </div>
+            </a>
+        </div> 
+    </div>
+</div>


### PR DESCRIPTION
## Purpose
Add the previous VS Code docs home page back.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs
